### PR TITLE
Fix not starting vitest process on windows

### DIFF
--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -86,7 +86,7 @@ export class TestRunner {
       "--reporter=json",
       "--reporter=verbose",
       "--outputFile",
-      isWindows ? `"${path.replace(/\\/g, "/")}"` : path,
+      path,
       "--run",
     ] as string[];
     if (testNamePattern) {
@@ -114,11 +114,14 @@ export class TestRunner {
       error = e;
     }
 
-    if (!existsSync(path)) {
+    const pathCleaned = isWindows? path.replace(/\\/g, "/"): path;
+
+    if (!existsSync(pathCleaned)) {
       await handleError();
     }
 
-    const file = await readFile(path, "utf-8");
+    const file = await readFile(pathCleaned, "utf-8");
+
     const out = JSON.parse(file) as FormattedTestResults;
     if (out.testResults.length === 0) {
       await handleError();


### PR DESCRIPTION
This change has been tested on both Windows and OSX test are running and reporting their status back correct.

In order to get it working on windows you have to remove the vitest setting `{PATH: "/path/to/node"}` from your settings.json.

Fixes #15 

Added a new issue which  will maybe make it easier to debug the issue next time #20